### PR TITLE
[BUGFIX] Add missing exit codes to all commands

### DIFF
--- a/Classes/Command/BackendApiCommandController.php
+++ b/Classes/Command/BackendApiCommandController.php
@@ -82,6 +82,7 @@ class BackendApiCommandController extends CommandController {
 			$this->outputLine($message);
 			$this->logger->info($message);
 		}
+        $this->quit(0);
 	}
 
 	/**
@@ -99,6 +100,7 @@ class BackendApiCommandController extends CommandController {
 				$message = 'Removed lock file \'typo3conf/LOCK_BACKEND\'';
 				$this->outputLine($message);
 				$this->logger->info($message);
+                $this->quit(0);
 			}
 		} else {
 			$message = 'No lock file \'typo3conf/LOCK_BACKEND\' was found, hence no lock could be removed.';

--- a/Classes/Command/BackendApiCommandController.php
+++ b/Classes/Command/BackendApiCommandController.php
@@ -82,7 +82,7 @@ class BackendApiCommandController extends CommandController {
 			$this->outputLine($message);
 			$this->logger->info($message);
 		}
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -100,7 +100,7 @@ class BackendApiCommandController extends CommandController {
 				$message = 'Removed lock file \'typo3conf/LOCK_BACKEND\'';
 				$this->outputLine($message);
 				$this->logger->info($message);
-                $this->quit(0);
+				$this->quit(0);
 			}
 		} else {
 			$message = 'No lock file \'typo3conf/LOCK_BACKEND\' was found, hence no lock could be removed.';

--- a/Classes/Command/CacheApiCommandController.php
+++ b/Classes/Command/CacheApiCommandController.php
@@ -86,6 +86,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'All caches have been cleared%s.';
 		$this->logger->info($message);
 		$this->outputLine($message, $hard ? array(' hard') : array(''));
+        $this->quit(0);
 	}
 
 	/**
@@ -103,6 +104,7 @@ class CacheApiCommandController extends CommandController {
 			$this->logger->info($message);
 			$this->outputLine($message);
 		}
+        $this->quit(0);
 	}
 
 	/**
@@ -115,6 +117,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'System cache has been cleared';
 		$this->logger->info($message);
 		$this->outputLine($message);
+        $this->quit(0);
 	}
 
 	/**
@@ -137,6 +140,7 @@ class CacheApiCommandController extends CommandController {
 			$this->outputLine($message);
 			$this->logger->info($message);
 		}
+        $this->quit(0);
 	}
 
 	/**
@@ -149,6 +153,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'Configuration cache has been cleared.';
 		$this->logger->info($message);
 		$this->outputLine($message);
+        $this->quit(0);
 	}
 
 	/**
@@ -161,6 +166,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'Page cache has been cleared.';
 		$this->logger->info($message);
 		$this->outputLine($message);
+        $this->quit(0);
 	}
 
 	/**
@@ -174,5 +180,6 @@ class CacheApiCommandController extends CommandController {
 		$message = 'Cleared caches: ' . implode(', ', $clearedCaches);
 		$this->logger->info($message);
 		$this->outputLine($message);
+        $this->quit(0);
 	}
 }

--- a/Classes/Command/CacheApiCommandController.php
+++ b/Classes/Command/CacheApiCommandController.php
@@ -86,7 +86,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'All caches have been cleared%s.';
 		$this->logger->info($message);
 		$this->outputLine($message, $hard ? array(' hard') : array(''));
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -104,7 +104,7 @@ class CacheApiCommandController extends CommandController {
 			$this->logger->info($message);
 			$this->outputLine($message);
 		}
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -117,14 +117,14 @@ class CacheApiCommandController extends CommandController {
 		$message = 'System cache has been cleared';
 		$this->logger->info($message);
 		$this->outputLine($message);
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
 	 * Clears the opcode cache.
 	 *
 	 * @param string|NULL $fileAbsPath The file as absolute path to be cleared
-	 *                                 or NULL to clear completely.
+	 *								 or NULL to clear completely.
 	 *
 	 * @return void
 	 */
@@ -140,7 +140,7 @@ class CacheApiCommandController extends CommandController {
 			$this->outputLine($message);
 			$this->logger->info($message);
 		}
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -153,7 +153,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'Configuration cache has been cleared.';
 		$this->logger->info($message);
 		$this->outputLine($message);
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -166,7 +166,7 @@ class CacheApiCommandController extends CommandController {
 		$message = 'Page cache has been cleared.';
 		$this->logger->info($message);
 		$this->outputLine($message);
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -180,6 +180,6 @@ class CacheApiCommandController extends CommandController {
 		$message = 'Cleared caches: ' . implode(', ', $clearedCaches);
 		$this->logger->info($message);
 		$this->outputLine($message);
-        $this->quit(0);
+		$this->quit(0);
 	}
 }

--- a/Classes/Command/ConfigurationApiCommandController.php
+++ b/Classes/Command/ConfigurationApiCommandController.php
@@ -47,6 +47,7 @@ class ConfigurationApiCommandController extends CommandController {
 	 */
 	public function listCommand() {
 		$this->outputLine(json_encode($this->configurationApiService->getConfigurationArray()));
+        $this->quit(0);
 	}
 
 	/**
@@ -57,5 +58,6 @@ class ConfigurationApiCommandController extends CommandController {
 	 */
 	public function showCommand($key) {
 		$this->outputLine(json_encode($this->configurationApiService->getValue($key)));
+        $this->quit(0);
 	}
 }

--- a/Classes/Command/ConfigurationApiCommandController.php
+++ b/Classes/Command/ConfigurationApiCommandController.php
@@ -47,7 +47,7 @@ class ConfigurationApiCommandController extends CommandController {
 	 */
 	public function listCommand() {
 		$this->outputLine(json_encode($this->configurationApiService->getConfigurationArray()));
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -58,6 +58,6 @@ class ConfigurationApiCommandController extends CommandController {
 	 */
 	public function showCommand($key) {
 		$this->outputLine(json_encode($this->configurationApiService->getValue($key)));
-        $this->quit(0);
+		$this->quit(0);
 	}
 }

--- a/Classes/Command/DatabaseApiCommandController.php
+++ b/Classes/Command/DatabaseApiCommandController.php
@@ -90,7 +90,7 @@ class DatabaseApiCommandController extends CommandController {
 			foreach ($actions as $number => $action) {
 				$this->outputLine('  - ' . $action . ' => ' . $number);
 			}
-			$this->quit();
+			$this->quit(0);
 		}
 
 		$result = $this->databaseApiService->databaseCompare($actions, $dry);
@@ -109,11 +109,13 @@ class DatabaseApiCommandController extends CommandController {
 				$this->outputLine(LF);
 			}
 			$this->logger->info('DB compare executed in dry mode');
+            $this->quit(0);
 		} else {
 			if (empty($result)) {
 				$message = 'DB has been compared';
 				$this->outputLine($message);
 				$this->logger->info($message);
+                $this->quit(0);
 			} else {
 				$message = vsprintf('DB could not be compared, Error(s): %s', array(LF . implode(LF, $result)));
 				$this->outputLine($message);

--- a/Classes/Command/DatabaseApiCommandController.php
+++ b/Classes/Command/DatabaseApiCommandController.php
@@ -109,13 +109,13 @@ class DatabaseApiCommandController extends CommandController {
 				$this->outputLine(LF);
 			}
 			$this->logger->info('DB compare executed in dry mode');
-            $this->quit(0);
+			$this->quit(0);
 		} else {
 			if (empty($result)) {
 				$message = 'DB has been compared';
 				$this->outputLine($message);
 				$this->logger->info($message);
-                $this->quit(0);
+				$this->quit(0);
 			} else {
 				$message = vsprintf('DB could not be compared, Error(s): %s', array(LF . implode(LF, $result)));
 				$this->outputLine($message);

--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -141,6 +141,7 @@ class ExtensionApiCommandController extends CommandController {
 		}
 
 		$this->logger->info('extensionApi:info executes successfully.');
+        $this->quit(0);
 	}
 
 	/**
@@ -173,6 +174,7 @@ class ExtensionApiCommandController extends CommandController {
 		$this->outputLine('%-2s%-40s', array(' ', str_repeat('-', $this->output->getMaximumLineLength() - 3)));
 		$this->outputLine('  Total: ' . count($extensions) . ' extensions');
 		$this->logger->info('extensionApi:listInstalled executed successfully');
+        $this->quit(0);
 	}
 
 	/**
@@ -193,6 +195,7 @@ class ExtensionApiCommandController extends CommandController {
 			$this->outputLine($message);
 			$this->logger->info($message);
 		}
+        $this->quit(0);
 	}
 
 	/**
@@ -216,6 +219,7 @@ class ExtensionApiCommandController extends CommandController {
 		$message = sprintf('Extension "%s" is now installed!', $key);
 		$this->outputLine($message);
 		$this->logger->info($message);
+        $this->quit(0);
 	}
 
 	/**
@@ -238,6 +242,7 @@ class ExtensionApiCommandController extends CommandController {
 		$message = sprintf('Extension "%s" is now uninstalled!', $key);
 		$this->outputLine($message);
 		$this->logger->info($message);
+        $this->quit(0);
 	}
 
 	/**
@@ -300,6 +305,7 @@ class ExtensionApiCommandController extends CommandController {
 		$message = sprintf('Extension "%s" has been configured!', $key);
 		$this->outputLine($message);
 		$this->logger->info($message);
+        $this->quit(0);
 	}
 
 	/**
@@ -319,6 +325,7 @@ class ExtensionApiCommandController extends CommandController {
 			$message = sprintf('Extension "%s" version %s has been fetched from repository! Dependencies were not resolved.', $data['main']['extKey'], $data['main']['version']);
 			$this->outputLine($message);
 			$this->logger->info($message);
+            $this->quit(0);
 		} catch (Exception $e) {
 			$message = $e->getMessage();
 			$this->outputLine($message);
@@ -347,6 +354,7 @@ class ExtensionApiCommandController extends CommandController {
 			$this->quit(1);
 		}
 		$this->logger->info('extensionApi:listMirrors executed successfully.');
+        $this->quit(0);
 	}
 
 	/**
@@ -364,6 +372,7 @@ class ExtensionApiCommandController extends CommandController {
 			$message = sprintf('Extension "%s" has been imported!', $data['extKey']);
 			$this->outputLine($message);
 			$this->logger->info($message);
+            $this->quit(0);
 		} catch (Exception $e) {
 			$this->outputLine($e->getMessage());
 			$this->logger->error($e->getMessage());

--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -372,7 +372,7 @@ class ExtensionApiCommandController extends CommandController {
 			$message = sprintf('Extension "%s" has been imported!', $data['extKey']);
 			$this->outputLine($message);
 			$this->logger->info($message);
-            $this->quit(0);
+			$this->quit(0);
 		} catch (Exception $e) {
 			$this->outputLine($e->getMessage());
 			$this->logger->error($e->getMessage());

--- a/Classes/Command/ImportExportApiCommandController.php
+++ b/Classes/Command/ImportExportApiCommandController.php
@@ -57,5 +57,6 @@ class ImportExportApiCommandController extends CommandController {
 		foreach ($messages AS $message) {
 			$this->outputLine($message);
 		}
+        $this->quit(0);
 	}
 }

--- a/Classes/Command/ImportExportApiCommandController.php
+++ b/Classes/Command/ImportExportApiCommandController.php
@@ -57,6 +57,6 @@ class ImportExportApiCommandController extends CommandController {
 		foreach ($messages AS $message) {
 			$this->outputLine($message);
 		}
-        $this->quit(0);
+		$this->quit(0);
 	}
 }

--- a/Classes/Command/SiteApiCommandController.php
+++ b/Classes/Command/SiteApiCommandController.php
@@ -94,6 +94,7 @@ class SiteApiCommandController extends CommandController {
 		}
 
 		$this->logger->info('siteApi:info executes successfully.');
+        $this->quit(0);
 	}
 
 	/**
@@ -120,5 +121,6 @@ class SiteApiCommandController extends CommandController {
 			$this->outputLine('News entry NOT created.');
 			$this->quit(1);
 		}
+        $this->quit(0);
 	}
 }

--- a/Classes/Command/SiteApiCommandController.php
+++ b/Classes/Command/SiteApiCommandController.php
@@ -94,7 +94,7 @@ class SiteApiCommandController extends CommandController {
 		}
 
 		$this->logger->info('siteApi:info executes successfully.');
-        $this->quit(0);
+		$this->quit(0);
 	}
 
 	/**
@@ -121,6 +121,6 @@ class SiteApiCommandController extends CommandController {
 			$this->outputLine('News entry NOT created.');
 			$this->quit(1);
 		}
-        $this->quit(0);
+		$this->quit(0);
 	}
 }


### PR DESCRIPTION
Succeeded tasks are tread as failed in SurfDeployment on PHP 7.0 without explicitly setting exit code 0.